### PR TITLE
SB-27610: Update table to use userid as partition key and id as clustering key

### DIFF
--- a/all-actors/src/main/java/org/sunbird/notification/actor/DeleteNotificationActor.java
+++ b/all-actors/src/main/java/org/sunbird/notification/actor/DeleteNotificationActor.java
@@ -21,6 +21,7 @@ import org.sunbird.util.Util;
 import org.sunbird.utils.PropertiesCache;
 
 import java.text.MessageFormat;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,7 +85,7 @@ public class DeleteNotificationActor extends BaseActor {
                 List<Map<String, Object>> mappedFeedIdLists = notificationService.getFeedMap((List<String>) request.getRequest().get(JsonKey.IDS), request.getContext());
                 getOtherVersionUpdatedFeedList(mappedFeedIdLists,feedIds);
             }
-            Response response = notificationService.deleteNotificationFeed(feedIds, request.getContext());
+            Response response = notificationService.deleteNotificationFeed(Collections.singletonMap(requestedBy,feedIds), request.getContext());
             if(isSupportEnabled){
                 notificationService.deleteNotificationFeedMap(feedIds,request.getContext());
             }

--- a/all-actors/src/main/java/org/sunbird/service/NotificationService.java
+++ b/all-actors/src/main/java/org/sunbird/service/NotificationService.java
@@ -28,7 +28,7 @@ public interface NotificationService {
 
     Response createV1NotificationFeed(List<NotificationFeed> feedList, Map<String,Object> reqContext) throws BaseException, JsonProcessingException;
 
-    Response deleteNotificationFeed(List<String> ids, Map<String,Object> reqContext) throws BaseException, JsonProcessingException;
+    Response deleteNotificationFeed(Map<String,List<String>> feedIdMap, Map<String,Object> reqContext) throws BaseException, JsonProcessingException;
 
     Response mapV1V2Feed(List<NotificationFeed> newFeedList, List<NotificationFeed> oldFeedList, Map<String, Object> reqContext);
 

--- a/all-actors/src/main/java/org/sunbird/service/NotificationServiceImpl.java
+++ b/all-actors/src/main/java/org/sunbird/service/NotificationServiceImpl.java
@@ -118,12 +118,15 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     @Override
-    public Response deleteNotificationFeed(List<String> ids, Map<String, Object> reqContext) throws BaseException, JsonProcessingException {
+    public Response deleteNotificationFeed(Map<String,List<String>> feedIdMap, Map<String, Object> reqContext) throws BaseException, JsonProcessingException {
         List<NotificationFeed> feeds = new ArrayList<>();
-        for (String feedId:ids) {
-            NotificationFeed feed = new NotificationFeed();
-            feed.setId(feedId);
-            feeds.add(feed);
+        for (Map.Entry<String,List<String>> feedItr:feedIdMap.entrySet()) {
+            for (String feedId: feedItr.getValue()) {
+                NotificationFeed feed = new NotificationFeed();
+                feed.setId(feedId);
+                feed.setUserId(feedItr.getKey());
+                feeds.add(feed);
+            }
         }
         if(CollectionUtils.isNotEmpty(feeds)) {
             return notificationDao.deleteUserFeed(feeds, reqContext);

--- a/all-actors/src/test/java/org/sunbird/notification/actor/UpdateNotificationActorTest.java
+++ b/all-actors/src/test/java/org/sunbird/notification/actor/UpdateNotificationActorTest.java
@@ -77,7 +77,7 @@ public class UpdateNotificationActorTest extends BaseActorTest{
         PowerMockito.mockStatic(ServiceFactory.class);
         cassandraOperation = mock(CassandraOperationImpl.class);
         when(ServiceFactory.getInstance()).thenReturn(cassandraOperation);
-        when(cassandraOperation.batchUpdateById(
+        when(cassandraOperation.batchUpdate(
                 Mockito.anyString(),
                 Mockito.anyString(),
                 Mockito.anyList(),
@@ -108,7 +108,7 @@ public class UpdateNotificationActorTest extends BaseActorTest{
         PowerMockito.mockStatic(ServiceFactory.class);
         cassandraOperation = mock(CassandraOperationImpl.class);
         when(ServiceFactory.getInstance()).thenReturn(cassandraOperation);
-        when(cassandraOperation.batchUpdateById(
+        when(cassandraOperation.batchUpdate(
                 Mockito.anyString(),
                 Mockito.anyString(),
                 Mockito.anyList(),


### PR DESCRIPTION
secondary index on notification_feed table on column userid was causing performance issue